### PR TITLE
Support for Subrs array containing Null

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,16 @@ impl TryIndex for Vec<Vec<u8>> {
         self.get(idx).map(|v| &**v)
     }
 }
+impl TryIndex for Vec<Option<Vec<u8>>> {
+    #[inline]
+    fn try_index(&self, idx: usize) -> Option<&[u8]> {
+        if let Some(w) = self.get(idx) {
+            w.as_ref().map(|v| &**v)
+        } else {
+            None
+        }
+    }
+}
 impl<'a> TryIndex for Vec<&'a [u8]> {
     #[inline]
     fn try_index(&self, idx: usize) -> Option<&[u8]> {

--- a/src/type1.rs
+++ b/src/type1.rs
@@ -97,10 +97,10 @@ impl Type1Font {
         };
         
         let char_strings = font_dict.get("CharStrings").expect("no /CharStrings").as_dict().unwrap();
-        
-        let subrs: Vec<Vec<u8>> = private_dict.get("Subrs").map(|subrs|
+
+        let subrs: Vec<Option<Vec<u8>>> = private_dict.get("Subrs").map(|subrs|
             subrs.as_array().unwrap().iter()
-            .map(|item| Decoder::charstring().decode(item.as_bytes().unwrap(), len_iv).into())
+            .map(|item| item.as_bytes().map(|b| Decoder::charstring().decode(b, len_iv).into()))
             .collect()
         ).unwrap_or_default();
         


### PR DESCRIPTION
Sometimes, some elements of the Subrs array are missing, especially in fonts embedded in PDFs.
This branch prevents calling `as_bytes().unwrap()` for `Item::Null` by making the elements of the Subrs array to `Optional` type.